### PR TITLE
add install script for elm. NB requires sudo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-build: clean compile
+build: install clean compile
 	echo "Building project"
 	cp -r public build
 	mv main.js build/main.js
@@ -9,3 +9,7 @@ compile: src/Main.elm
 .PHONY: clean
 clean:
 	rm -rf build/
+
+.PHONY: install
+install:
+	./installElm.sh

--- a/installElm.sh
+++ b/installElm.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+REPOURL="https://github.com/elm/compiler/releases/download/0.19.1/binary-for-linux-64-bit.gz"
+INSTALLOCATION="/usr/local/bin"
+
+echo "Check for installation"
+if [ ! -e "${INSTALLOCATION}/elm" ]
+then
+    echo "No installation detected at ${INSTALLOCATION}, installing..."
+    echo "Download code from ${REPOURL}"
+    curl -L -o elm.gz $REPOURL
+    echo "Unzip"
+    gunzip elm.gz
+    echo "Mark elm executable as, well, executable"
+    chmod +x elm
+    echo "Move elm to some file in PATH ${INSTALLOCATION}"
+    sudo mv elm $INSTALLOCATION
+else
+    echo "Elm detected in ${INSTALLOCATION}, all in order"
+fi
+


### PR DESCRIPTION
Ait så dette scriptet burde funke for å installere elm, men om det kjøres uten sudo blir man prompta for et passord når kompilatoren skal flyttes til /usr/local/bin for å ligge i en mappe i PATH. Så om det går ann  å deploye denne avhenger av setupen til netlify