### PR TITLE
Justeringer av layout og innhold på landingsside for å få den til å funke bedre på mobil

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,13 @@
-# Getting Started with Create React App
+# Dot-no-front: Mjukvarelaugets hjemmeside
+Mjukvarelaugets hjemmeside, med blogg, prosjektsider, de nyeste albummene fra Astronomisk Tussmørke, og mye annet ræl.
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+## Byggeprosess
+Sia er satt opp med create-react-app, og bruker npm som byggsystem. Installer avhengigheter med
+```
+npm i
+```
 
-## Available Scripts
+Deretter kan sia testes med `npm start`, eller bygges med `npm run build`.
 
-In the project directory, you can run:
-
-### `yarn start`
-
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
-
-The page will reload if you make edits.\
-You will also see any lint errors in the console.
-
-### `yarn test`
-
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `yarn build`
-
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `yarn eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
-
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
-
-### Analyzing the Bundle Size
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
-
-### Making a Progressive Web App
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
-
-### Advanced Configuration
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
-
-### Deployment
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
-
-### `yarn build` fails to minify
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+## React og Elm
+Hjemmesiden kjører som en react-app, men enkelte komponenter er skrevet i Elm. Byggprosessen inkluderer derfor et kompileringssteg fra Elm til javascript/react. Det er imidlertid ikke mulig å se output fra Elm-kompilatoren når man bruker de vanlige byggscriptene. For å se advarsler og feil fra elm-kompilerier det satt opp et script i `npm run testelm`, dette kompilerer elm-filene, printer eventuelle feilmeldinger og skriver resultatet til /dev/null.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package",
+    "testelm": "elm make --output=/dev/null src/ElmMain.elm"
   },
   "eslintConfig": {
     "extends": [

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import "./App.css";
 import Elm from "react-elm-components";
 import StartPage from "./ElmMain.elm";
-import { BrowserRouter as Router, Switch, Route, Link } from "react-router-dom";
+import { BrowserRouter as Router, Switch, Route} from "react-router-dom";
 import Blog from "./Blog/List.elm";
 import Post from "./Blog/Post";
 

--- a/src/Blog/Post.js
+++ b/src/Blog/Post.js
@@ -63,6 +63,7 @@ const Post = () => {
               <p>Lesetid: ca.{articleReadLength(post.body)} minutter</p>
             </div>
             <img
+	      alt={post.imgAlt}
               className={styles.responsive}
               src={urlFor(post.mainImage).width(1200)}
             />

--- a/src/ElmMain.elm
+++ b/src/ElmMain.elm
@@ -39,9 +39,9 @@ emptyArticle =
 ---- MODEL ----
 cmsApiUrlBase = "https://ll3wkgw3.api.sanity.io/v1/data/query/production/"
 cmsUrlBase = "https://cdn.sanity.io/"
--- Evntually we'll want to fetch 4 posts in total, but the cms does only contain 3 atm
+-- Only fetches the 3 most recent to display in homepage
 articlesQuery = """
-*[_type == 'post'] | [0..3] | order(_createdAt asc) | 
+*[_type == 'post'] | [0..2] | order(_createdAt asc) | 
 {
 author->{name}, 
 body[0]{children[0]{text}}, 
@@ -236,6 +236,11 @@ showLoadedArticles articles =
         , div
              [class "articles-list"]
              (List.map (articleView << Valid) articles)
+        , div [class "blog-link-wrapper"] [
+              a [class "blog-link", href "/blog/"] [
+                   text "Se alle innlegg"
+                  ]
+             ]
         ]
             
 articleView : Resource Article -> Html Msg

--- a/src/ElmMain.elm
+++ b/src/ElmMain.elm
@@ -222,59 +222,16 @@ articlesView model =
             showLoadedArticles articles
 
 showLoadedArticles : (List Article) -> Html Msg
-showLoadedArticles articles =
-    let
-        featuredArticle =
-            case List.head articles of
-                Just article -> article
-                Nothing -> emptyArticle
-                           
-        restOfArticles =
-            case List.tail articles of
-                Just rest -> rest
-                Nothing -> [emptyArticle]
-    in
-        -- "<<" is function composition (f << g) x  == f(g(x))
-        div [class "articles-wrapper" ] [
-             featuredArticleView (Valid featuredArticle)
-            , div [class "articles-list"] (List.map (articleView << Valid) restOfArticles)
-            ]
-   
-featuredArticleView : Resource Article -> Html Msg
-featuredArticleView article =
-    case article of
-        Valid content ->
-            div [class "featured-article"] [
-                 div [class "featured-image-box"] [
-                      img [
-                        class "featured-image"
-                      , src content.imageURL
-                      , alt content.imgAlt] []
-                     ]
-                     
-                , div [class "featured-text"] [
-                      a [class "featured-heading", href ("/blog/" ++ content.slug)] [
-                           h2 [class "no-top-margin"] [
-                                text content.title
-                               ]
-                          ]
-                     , dividerLineShort
-                     , p [class "text-box-text"] [
-                           text content.ingress
-                          ]
-                     ]
-               ]
-                
-        Empty ->
-            div [class "featured-article"] [
-                 text "Loading featured article"
-                ]
-
-        Failed message ->
-            div [class "featured-article"] [
-                 text ("Featured article load failed: " ++ message)
-                ]
-
+showLoadedArticles articles =    
+    -- "<<" is function composition (f << g) x  == f(g(x))
+    div [class "articles-wrapper" ] [
+         h1 [class "articles-header"] [
+              text "Prosjekter og blogginnlegg"
+             ]
+        , div
+             [class "articles-list"]
+             (List.map (articleView << Valid) articles)
+        ]
             
 articleView : Resource Article -> Html Msg
 articleView article =

--- a/src/ElmMain.elm
+++ b/src/ElmMain.elm
@@ -13,6 +13,8 @@ import Array
 
 import DividerLine exposing ( dividerLine, dividerLineShort )
 
+softHyphen = "\u{00AD}"
+
 ---- MODEL ----
 subHeaderList : List String
 subHeaderList =
@@ -173,7 +175,10 @@ headerView model =
 
     in
         div [ class "title" ]
-            [ h1 [ class "title-top" ] [ text "Mjukvarelauget" ]
+            [ h1 [ class "title-top" ]
+                  [
+                   text ("Mjukvare"++softHyphen++"lauget")
+                  ]
             , dividerLineShort
             , h2 [ class "title-bottom"] [ text headerText ]
             ]

--- a/src/index.css
+++ b/src/index.css
@@ -75,16 +75,30 @@ p {
 .articles-list {
   margin: 50px 0px 50px 0px;
   display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
 }
 
 .article-box {
   margin: 0px 20px 0px 20px;
-  height: 200px;
-  width: 33%;
+  height: 300px;
+  width: calc(33% - 40px);
 }
 
 .articles-header {
     text-align: center;
+}
+
+.blog-link-wrapper {
+    display: flex;
+    justify-content: end;
+}
+
+.blog-link {
+    position: relative;
+    bottom: 30px;
+    right: 50px;
+    font-size: calc(var(--content-font-size) * 2);
 }
 
 @media only screen and (max-width: 800px) {

--- a/src/index.css
+++ b/src/index.css
@@ -72,34 +72,6 @@ p {
   text-align: right;
 }
 
-.featured-article {
-  display: flex;
-  margin: 20px 20px 0px 20px;
-  font-size: var(--content-font-size);
-  height: 14em;
-}
-
-.featured-heading {
-  font-size: 30px;
-  height: 20%;
-}
-
-.featured-image {
-  height: 100%;
-  width: 100%;
-}
-
-.featured-image-box {
-  width: 33%;
-  object-fit: cover;
-  margin-right: 20px;
-}
-
-.featured-text {
-  width: 66%;
-  text-align: center;
-}
-
 .articles-list {
   margin: 50px 0px 50px 0px;
   display: flex;
@@ -109,6 +81,10 @@ p {
   margin: 0px 20px 0px 20px;
   height: 200px;
   width: 33%;
+}
+
+.articles-header {
+    text-align: center;
 }
 
 @media only screen and (max-width: 800px) {

--- a/src/index.css
+++ b/src/index.css
@@ -81,7 +81,7 @@ p {
 
 .article-box {
   margin: 0px 20px 0px 20px;
-  height: 300px;
+  height: 200px;
   width: calc(33% - 40px);
 }
 
@@ -91,21 +91,21 @@ p {
 
 .blog-link-wrapper {
     display: flex;
-    justify-content: end;
+    justify-content: flex-end;
 }
 
 .blog-link {
     position: relative;
     bottom: 30px;
     right: 50px;
-    font-size: calc(var(--content-font-size) * 2);
+    font-size: calc(var(--content-font-size) * 1.5);
 }
 
 @media only screen and (max-width: 800px) {
   .article-box {
     margin: 20px 20px 20px 20px;
     height: 60vw;
-    width: 100%;
+    width: calc(100% - 40px);
   }
 
   .articles-list {


### PR DESCRIPTION
- Fjern "featured article" fra layout på forside, kun tre artikler som vises enten som tre-kolonne eller en-kolonne avhengig av skjermstørrelse.
- Soft hyphen i overskrift på forside slik at den faktisk har plass på en mobilskjerm (Mjukvare-lauget). 
- Div justeringer av css. La til script i package.json for debugging av elm (kompilerer, skriver resultat til /dev/null. For å kunne se feilmeldinger fra kompilatoren, noe React ikke viser). 
- La til lenke til /blog under artikkeloversikt
- Oppdater readme med litt prosjektinfo og byggprosess